### PR TITLE
Add Docker support

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+**/__pycache__
+aws-uploader-frontend/node_modules
+aws-uploader-frontend/dist
+aws-image-uploader/__pycache__
+.git

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,16 @@
+FROM node:20 AS frontend
+WORKDIR /frontend
+COPY aws-uploader-frontend/package.json aws-uploader-frontend/pnpm-lock.yaml ./
+RUN npm install -g pnpm \
+    && pnpm install
+COPY aws-uploader-frontend/ ./
+RUN pnpm run build
+
+FROM python:3.11-slim AS backend
+WORKDIR /app
+COPY aws-image-uploader/requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+COPY aws-image-uploader/ ./
+COPY --from=frontend /frontend/dist ./src/static
+EXPOSE 8000
+CMD ["python", "src/main.py"]

--- a/README.md
+++ b/README.md
@@ -76,3 +76,18 @@ O projeto é dividido em duas partes principais:
 -   O domínio `https://d1jc1l746atx5b.cloudfront.net/` é usado para gerar as URLs das imagens no JSON, conforme o script original.
 
 
+
+## Executar com Docker
+
+A aplicação pode ser executada em um único container Docker que já inclui o backend em Flask e o frontend compilado.
+
+1. Construa a imagem:
+   ```bash
+   docker build -t aws-uploader .
+   ```
+2. Inicie o container mapeando a porta 8000:
+   ```bash
+   docker run --rm -p 8000:8000 aws-uploader
+   ```
+
+Depois disso, acesse `http://localhost:8000` no navegador para utilizar a interface.


### PR DESCRIPTION
## Summary
- add Dockerfile with multi-stage build for backend/frontend
- ignore build artifacts when building Docker
- update README with Docker run instructions

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `npm --version`
- `pnpm --version`


------
https://chatgpt.com/codex/tasks/task_e_685f65cd9b00832d9cd849447bfa09e0