### PR TITLE
Add Docker helper script and use server AWS credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,13 +81,11 @@ O projeto é dividido em duas partes principais:
 
 A aplicação pode ser executada em um único container Docker que já inclui o backend em Flask e o frontend compilado.
 
-1. Construa a imagem:
-   ```bash
-   docker build -t aws-uploader .
-   ```
-2. Inicie o container mapeando a porta 8000:
-   ```bash
-   docker run --rm -p 8000:8000 aws-uploader
-   ```
+Execute o script `build_and_run.sh` para construir a imagem e iniciar o container
+utilizando automaticamente as credenciais AWS configuradas no servidor:
+
+```bash
+./build_and_run.sh
+```
 
 Depois disso, acesse `http://localhost:8000` no navegador para utilizar a interface.

--- a/aws-image-uploader/src/routes/aws.py
+++ b/aws-image-uploader/src/routes/aws.py
@@ -60,13 +60,12 @@ def setup_folders():
     """Cria estrutura de pastas no S3"""
     data = request.json
     wl_name = data.get('wl_name')
-    profile_name = data.get('profile_name')
 
     if not wl_name:
         return jsonify({'error': 'Nome WL é obrigatório'}), 400
 
     try:
-        s3_client = get_s3_client(profile_name)
+        s3_client = get_s3_client()
         base_path = f"app/{wl_name}/home"
 
         folders = [
@@ -94,7 +93,6 @@ def upload_images():
     """Faz upload de imagens para S3"""
     try:
         wl_name = request.form.get('wl_name')
-        profile_name = request.form.get('profile_name')
         folder_type = request.form.get('folder_type')
 
         if not all([wl_name, folder_type]):
@@ -107,7 +105,7 @@ def upload_images():
         if not files or files[0].filename == '':
             return jsonify({'error': 'Nenhum arquivo selecionado'}), 400
 
-        s3_client = get_s3_client(profile_name)
+        s3_client = get_s3_client()
         base_path = f"app/{wl_name}/home"
 
         uploaded_files = []
@@ -170,9 +168,8 @@ def test_aws_connection():
     """Testa conexão com AWS"""
     try:
         data = request.json
-        profile_name = data.get('profile_name')
 
-        s3_client = get_s3_client(profile_name)
+        s3_client = get_s3_client()
 
         # Tenta listar buckets para testar conexão
         s3_client.list_buckets()

--- a/aws-uploader-frontend/src/App.jsx
+++ b/aws-uploader-frontend/src/App.jsx
@@ -26,9 +26,6 @@ const FOLDER_TYPES = {
 
 function App() {
   const [wlName, setWlName] = useState('')
-  const [profileName, setProfileName] = useState('default')
-  const [isCustomProfile, setIsCustomProfile] = useState(false)
-  const [customProfileName, setCustomProfileName] = useState('')
   const [isSetupComplete, setIsSetupComplete] = useState(false)
   const [loading, setLoading] = useState(false)
   const [message, setMessage] = useState('')
@@ -65,13 +62,10 @@ function App() {
 
     setLoading(true)
     try {
-      const profile = isCustomProfile ? customProfileName : 'default'
-
       // Testar conexão AWS
       const testResponse = await fetch(`${API_BASE_URL}/test-aws-connection`, {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ profile_name: profile })
+        headers: { 'Content-Type': 'application/json' }
       })
 
       if (!testResponse.ok) {
@@ -80,22 +74,20 @@ function App() {
       }
 
       // Criar estrutura de pastas
-      const setupResponse = await fetch(`${API_BASE_URL}/setup-folders`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          wl_name: wlName,
-          profile_name: profile
+        const setupResponse = await fetch(`${API_BASE_URL}/setup-folders`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            wl_name: wlName
+          })
         })
-      })
 
       if (!setupResponse.ok) {
         const error = await setupResponse.json()
         throw new Error(error.error || 'Erro ao criar estrutura de pastas')
       }
 
-      setProfileName(profile)
-      setIsSetupComplete(true)
+        setIsSetupComplete(true)
       showMessage('Configuração concluída com sucesso!', 'success')
 
     } catch (error) {
@@ -112,7 +104,6 @@ function App() {
     try {
       const formData = new FormData()
       formData.append('wl_name', wlName)
-      formData.append('profile_name', profileName)
       formData.append('folder_type', folderType)
 
       Array.from(files).forEach(file => {
@@ -306,30 +297,7 @@ function App() {
                 />
               </div>
 
-              <div>
-                <Label>Perfil AWS SSO</Label>
-                <Select value={isCustomProfile ? 'custom' : 'default'} onValueChange={(value) => setIsCustomProfile(value === 'custom')}>
-                  <SelectTrigger>
-                    <SelectValue />
-                  </SelectTrigger>
-                  <SelectContent>
-                    <SelectItem value="default">Perfil Padrão</SelectItem>
-                    <SelectItem value="custom">Perfil Personalizado</SelectItem>
-                  </SelectContent>
-                </Select>
-              </div>
 
-              {isCustomProfile && (
-                <div>
-                  <Label htmlFor="profile-name">Nome do Perfil</Label>
-                  <Input
-                    id="profile-name"
-                    placeholder="nome-do-perfil"
-                    value={customProfileName}
-                    onChange={(e) => setCustomProfileName(e.target.value)}
-                  />
-                </div>
-              )}
 
               <Button
                 onClick={handleSetup}

--- a/build_and_run.sh
+++ b/build_and_run.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+set -e
+
+IMAGE_NAME="aws-uploader"
+
+# Build Docker image
+docker build -t "$IMAGE_NAME" .
+
+# Run container mounting AWS credentials
+docker run --rm -p 8000:8000 -v "$HOME/.aws":/root/.aws:ro "$IMAGE_NAME"


### PR DESCRIPTION
## Summary
- add `build_and_run.sh` helper to build image and run container mounting AWS creds
- simplify backend routes to always use server credentials
- remove profile selection from frontend
- update README with new script instructions

## Testing
- `pnpm -v`

------
https://chatgpt.com/codex/tasks/task_e_685f6bd54024832d848eaf18a6cbffc9