### PR TITLE
Fix AWS test endpoint missing JSON body

### DIFF
--- a/aws-image-uploader/src/routes/aws.py
+++ b/aws-image-uploader/src/routes/aws.py
@@ -167,7 +167,11 @@ def generate_json():
 def test_aws_connection():
     """Testa conexão com AWS"""
     try:
-        data = request.json
+        # Nenhum corpo JSON é necessário para esse endpoint, mas
+        # request.get_json() é chamado em modo silencioso para evitar erros
+        # quando o cliente envia uma requisição sem corpo ou cabeçalho
+        # Content-Type incorreto.
+        request.get_json(silent=True)
 
         s3_client = get_s3_client()
 


### PR DESCRIPTION
## Summary
- silence JSON parsing on `/test-aws-connection` endpoint so requests without body don't raise errors

## Testing
- `python3 -m py_compile aws-image-uploader/src/routes/aws.py`


------
https://chatgpt.com/codex/tasks/task_e_685f6db8a8f8832d9a525fada8439341